### PR TITLE
Move doc link to button

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,14 +30,14 @@ module.exports = {
         path: 'faq.md'
       },
       {
-        title: 'Documentation',
-        path: 'https://www.adobe.com/go/photoshop-api-docs-home'
-      },
-      {
         title: 'Get Started',
         path: 'signup.md?ref=signup'
       }
-    ]
+    ],
+    docs: {
+      title: 'View Docs',
+      path: 'https://www.adobe.com/go/photoshop-api-docs-home'
+    }
   },
   plugins: [`@adobe/gatsby-theme-aio`],
   pathPrefix: process.env.PATH_PREFIX || '/photoshop/api/'


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-09-01 at 10 53 17 AM" src="https://user-images.githubusercontent.com/6012307/131642256-ecae3f9c-beca-491a-9678-68071c3885b1.png">

Use the dedicated docs button to link to the docs similar to https://www.adobe.io/creative-cloud-libraries/